### PR TITLE
publish docker image

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up QEMU  # Virtualization tool 
+      - name: Set up QEMU  # Virtualization tool  
         uses: docker/setup-qemu-action@v2
     
       - name: Set up Docker Buildx

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [ "develop" ]
-    tags: [*]
+    tags: ["*"]
   pull_request:
     branches: [ "develop" ]
 

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -1,6 +1,7 @@
 name: Go Build
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "develop" ]
     tags: [*]

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -3,6 +3,7 @@ name: Go Build
 on:
   push:
     branches: [ "develop" ]
+    tags: [*]
   pull_request:
     branches: [ "develop" ]
 
@@ -41,3 +42,36 @@ jobs:
           echo "KUBEBUILDER_ASSETS=$(bin/setup-envtest use $ENVTEST_K8S_VERSION -p path)" >> $GITHUB_ENV
       - name: Test
         run: go test ./...
+  Release:
+    needs: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up QEMU  # Virtualization tool 
+        uses: docker/setup-qemu-action@v2
+    
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Build and push snapshot
+        if: github.ref != 'refs/heads/main'
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: konfirm:${{ github.sha }}
+      - name: set RELEASE_VERSION 
+        if: github.ref == 'refs/heads/main'
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Build and push release
+        if: env.RELEASE_VERSION != ''
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: konfirm:${{ env.RELEASE_VERSION }}

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -66,8 +66,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: konfirm:${{ github.sha }}
-          githubOrg: rafttech
+          tags: rafttech/konfirm:${{ github.sha }}
       - name: set RELEASE_VERSION 
         if: github.ref == 'refs/heads/main'
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
@@ -76,5 +75,4 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: konfirm:${{ env.RELEASE_VERSION }}
-          githubOrg: rafttech
+          tags: rafttech/konfirm:${{ env.RELEASE_VERSION }}

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           push: true
           tags: konfirm:${{ github.sha }}
+          githubOrg: rafttech
       - name: set RELEASE_VERSION 
         if: github.ref == 'refs/heads/main'
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -76,3 +76,4 @@ jobs:
         with:
           push: true
           tags: konfirm:${{ env.RELEASE_VERSION }}
+          githubOrg: rafttech


### PR DESCRIPTION
## What's Included
Publishes docker image snapshot in build pipeline if the workflow is not triggered by a tagged release.
Publishes a docker image with the actual release version as the image tag when a release is cut.